### PR TITLE
[WIP] feat: return response object when making order

### DIFF
--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -76,6 +76,13 @@ export interface TraderOrder extends Trader {
 
 export type Order = OpenseaOrder | TraderOrder;
 
+interface MakeOrderError {
+  marketplaceName: MarketplaceName;
+  error: string;
+}
+
+export type MakeOrderResponse = Order | MakeOrderError;
+
 export interface GetOrdersParams {
   maker?: string;
   makerAsset?: Asset;


### PR DESCRIPTION
- do not throw when error is encountered; this is so in the event where one order goes through and one fails, we can handle both

@leeyikjiun @kainanaina 

Let me know if the approach is going in the right direction

Also of note:
Opensea seems to throw with Error objects all the time (which is good), but traderXYZ seems to throw a mix of error object + [JSON responses](https://github.com/trader-xyz/nft-swap-sdk/blob/5aff4761f8e47c9aa60f345ba86794b1ece6943f/src/sdk/v4/orderbook.ts#L65)
May need to do some sanitization from the TraderXYZ marketplace SDK side