### PR TITLE
Basic swap sdk (inside Gomu sdk) that makes and takes orders, without orderbook

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,7 +3,7 @@ import { Web3Provider } from "@ethersproject/providers";
 
 import { Opensea } from "./marketplaces/Opensea";
 import { Trader } from "./marketplaces/Trader";
-import { SwapSdk } from "./swap";
+import { SwapSdk, throwSwapSdkUnsupportedChainError } from "./swap";
 
 import type { OpenseaConfig } from "./marketplaces/Opensea";
 import type { TraderConfig } from "./marketplaces/Trader";
@@ -102,7 +102,7 @@ export class Gomu {
       });
     }
 
-    if (SwapSdk.supportedChainIds.includes(chainId)) {
+    if (SwapSdk.supportsChainId(chainId)) {
       this.swapSdk = new SwapSdk({
         ...swapSdkConfig,
         address,
@@ -220,16 +220,6 @@ export class Gomu {
     };
   }
 
-  throwSwapSdkUnsupportedChainError(): void {
-    throw new Error(
-      `Chain ID ${
-        this.chainId
-      } is not supported by swapSdk. Supported chain ids: ${JSON.stringify(
-        SwapSdk.supportedChainIds
-      )}`
-    );
-  }
-
   async makeSwapOrder({
     makerAssets,
     takerAssets,
@@ -238,7 +228,7 @@ export class Gomu {
     takerAssets: Asset[];
   }): Promise<SignedSwapOrder | void> {
     if (!this.swapSdk) {
-      return this.throwSwapSdkUnsupportedChainError();
+      return throwSwapSdkUnsupportedChainError(this.chainId);
     }
 
     return this.swapSdk.makeOrder({ makerAssets, takerAssets });
@@ -252,7 +242,7 @@ export class Gomu {
     gasLimit?: number;
   }): Promise<any | void> {
     if (!this.swapSdk) {
-      return this.throwSwapSdkUnsupportedChainError();
+      return throwSwapSdkUnsupportedChainError(this.chainId);
     }
 
     return this.swapSdk.takeOrder({ order, gasLimit });

--- a/packages/sdk/src/swap/index.ts
+++ b/packages/sdk/src/swap/index.ts
@@ -44,11 +44,7 @@ export class SwapSdk {
     return supportedChainIds.includes(chainId);
   }
 
-  async approveAssetsStatuses({
-    assets,
-  }: {
-    assets: SwappableAsset[];
-  }): Promise<void> {
+  async approveAssetsStatuses(assets: SwappableAsset[]): Promise<void> {
     const approvalStatuses = await Promise.all(
       assets.map((asset) => {
         return this.sdk.loadApprovalStatus(asset, this.address);
@@ -89,7 +85,8 @@ export class SwapSdk {
       this.transformAssetsToSwappableAssets(makerAssets);
     const swappableTakerAssets =
       this.transformAssetsToSwappableAssets(takerAssets);
-    await this.approveAssetsStatuses({ assets: swappableMakerAssets });
+
+    await this.approveAssetsStatuses(swappableMakerAssets);
 
     const order = this.sdk.buildOrder(
       swappableMakerAssets,
@@ -110,7 +107,7 @@ export class SwapSdk {
   }): Promise<any> {
     const { takerAssets } = this.sdk.getAssetsFromOrder(order);
 
-    await this.approveAssetsStatuses({ assets: takerAssets });
+    await this.approveAssetsStatuses(takerAssets);
 
     const fillTx = await this.sdk.fillSignedOrder(order, undefined, {
       gasLimit,

--- a/packages/sdk/src/swap/index.ts
+++ b/packages/sdk/src/swap/index.ts
@@ -1,0 +1,118 @@
+import { Signer } from "@ethersproject/abstract-signer";
+import { Web3Provider } from "@ethersproject/providers";
+import {
+  NftSwapV3,
+  type SwappableAsset,
+  SignedOrder,
+} from "@traderxyz/nft-swap-sdk";
+
+import { Asset } from "../types";
+
+export interface SwapSdkConfig {
+  gasLimit?: number;
+}
+
+export interface _SwapSdkConfig extends SwapSdkConfig {
+  address: string;
+  chainId: number;
+  provider: Web3Provider;
+  signer: Signer;
+}
+
+export class SwapSdk {
+  private address: string;
+  private sdk: NftSwapV3;
+  private gasLimit = 350000;
+
+  constructor({
+    address,
+    chainId,
+    provider,
+    signer,
+    gasLimit,
+  }: _SwapSdkConfig) {
+    this.address = address;
+    this.sdk = new NftSwapV3(provider, signer, chainId);
+    if (gasLimit) {
+      this.gasLimit = gasLimit;
+    }
+  }
+
+  static supportedChainIds = [1, 4];
+
+  async approveAssetsStatuses({
+    assets,
+  }: {
+    assets: SwappableAsset[];
+  }): Promise<void> {
+    const approvalStatuses = await Promise.all(
+      assets.map((asset) => {
+        return this.sdk.loadApprovalStatus(asset, this.address);
+      })
+    );
+
+    await Promise.all(
+      approvalStatuses.map(async (status, index) => {
+        if (status.contractApproved) return;
+        const asset = assets[index];
+        const approvalTx = await this.sdk.approveTokenOrNftByAsset(
+          asset,
+          this.address
+        );
+        await approvalTx.wait();
+      })
+    );
+  }
+
+  transformAssetsToSwappableAssets(assets: Asset[]): SwappableAsset[] {
+    return assets.map(({ contractAddress, amount, ...rest }: any) => {
+      return {
+        ...rest,
+        tokenAddress: contractAddress,
+        ...(amount && { amount: String(amount) }),
+      };
+    });
+  }
+
+  async makeOrder({
+    makerAssets,
+    takerAssets,
+  }: {
+    makerAssets: Asset[];
+    takerAssets: Asset[];
+  }): Promise<SignedOrder> {
+    const swappableMakerAssets =
+      this.transformAssetsToSwappableAssets(makerAssets);
+    const swappableTakerAssets =
+      this.transformAssetsToSwappableAssets(takerAssets);
+    await this.approveAssetsStatuses({ assets: swappableMakerAssets });
+
+    const order = this.sdk.buildOrder(
+      swappableMakerAssets,
+      swappableTakerAssets,
+      this.address
+    );
+    const signedOrder = await this.sdk.signOrder(order, this.address);
+
+    return signedOrder;
+  }
+
+  async takeOrder({
+    order,
+    gasLimit = this.gasLimit,
+  }: {
+    order: SignedOrder;
+    gasLimit?: number;
+  }): Promise<any> {
+    const { takerAssets } = this.sdk.getAssetsFromOrder(order);
+
+    await this.approveAssetsStatuses({ assets: takerAssets });
+
+    const fillTx = await this.sdk.fillSignedOrder(order, undefined, {
+      gasLimit,
+    });
+
+    const fillTxReceipt = await this.sdk.awaitTransactionHash(fillTx.hash);
+    return fillTxReceipt;
+  }
+}

--- a/packages/sdk/src/swap/index.ts
+++ b/packages/sdk/src/swap/index.ts
@@ -19,6 +19,8 @@ export interface _SwapSdkConfig extends SwapSdkConfig {
   signer: Signer;
 }
 
+export const supportedChainIds = [1, 4];
+
 export class SwapSdk {
   private address: string;
   private sdk: NftSwapV3;
@@ -38,7 +40,9 @@ export class SwapSdk {
     }
   }
 
-  static supportedChainIds = [1, 4];
+  static supportsChainId(chainId: number): boolean {
+    return supportedChainIds.includes(chainId);
+  }
 
   async approveAssetsStatuses({
     assets,
@@ -116,3 +120,11 @@ export class SwapSdk {
     return fillTxReceipt;
   }
 }
+
+export const throwSwapSdkUnsupportedChainError = (chainId: number): void => {
+  throw new Error(
+    `Chain ID ${chainId} is not supported by swapSdk. Supported chain ids: ${JSON.stringify(
+      supportedChainIds
+    )}`
+  );
+};

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -2,8 +2,11 @@ import type {
   ContractReceipt,
   ContractTransaction,
 } from "@ethersproject/contracts";
+import type { SignedOrder } from "@traderxyz/nft-swap-sdk";
 import type { PostOrderResponsePayload } from "@traderxyz/nft-swap-sdk/dist/sdk/v4/orderbook";
 import type { Order as _OpenseaOrder } from "opensea-js/lib/types";
+
+export type SignedSwapOrder = SignedOrder;
 
 export interface Erc20Asset {
   contractAddress: string;


### PR DESCRIPTION
1) Add `swapSdk` to `Gomu` sdk.
2) Add 2 new methods to `Gomu` sdk - `makeSwapOrder` (returns signed order) and `takeSwapOrder` (takes signed orders).
3) Both new methods are currently not very useful without orderbook, so this PR can be frozen for a while.
4) Also v3 SDK got method for cancelling orders, but I'm not sure what is the purpose of it, since people who manage order book can do a better job, without any gass fees.