### PR TITLE
Return normalizedOrder together with marketplaceOrder

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -112,14 +112,19 @@ export class Gomu {
         })
         .map(async ([marketplaceName, marketplace]) => {
           try {
+            const marketplaceOrder = await marketplace.makeOrder(params);
+            const normalizedOrder =
+              marketplace.getNormalizedOrder(marketplaceOrder);
+
             return {
               marketplaceName: marketplaceName as MarketplaceName,
-              marketplaceOrder: await marketplace.makeOrder(params),
+              marketplaceOrder,
+              normalizedOrder,
             } as Order;
           } catch (err) {
             return {
               marketplaceName: marketplaceName as MarketplaceName,
-              error: err instanceof Error ? err.message : "" + err,
+              error: err instanceof Error ? err.message : String(err),
             };
           }
         })

--- a/packages/sdk/src/marketplaces/Marketplace.ts
+++ b/packages/sdk/src/marketplaces/Marketplace.ts
@@ -1,4 +1,8 @@
-import type { GetOrdersParams, MakeOrderParams } from "../types";
+import type {
+  GetOrdersParams,
+  MakeOrderParams,
+  NormalizedOrder,
+} from "../types";
 
 export interface Marketplace<Order> {
   makeOrder({
@@ -17,4 +21,6 @@ export interface Marketplace<Order> {
 
   takeOrder(order: Order): Promise<any>;
   cancelOrder(order: Order): Promise<any>;
+
+  getNormalizedOrder(order: Order): NormalizedOrder;
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -5,6 +5,9 @@ import type {
 import type { PostOrderResponsePayload } from "@traderxyz/nft-swap-sdk/dist/sdk/v4/orderbook";
 import type { Order as _OpenseaOrder } from "opensea-js/lib/types";
 
+export type OpenseaOriginalOrder = _OpenseaOrder;
+export type TraderOriginalOrder = PostOrderResponsePayload;
+
 export interface Erc20Asset {
   contractAddress: string;
   type: "ERC20";
@@ -66,12 +69,28 @@ interface Trader {
   marketplaceName: MarketplaceName.Trader;
 }
 
+export interface NormalizedOrder {
+  id: string;
+  asset: {
+    contractAddress: string;
+    tokenId: string;
+    type: string;
+    amount: string;
+  };
+  erc20Asset: {
+    contractAddress: string;
+    amount: string;
+  };
+}
+
 export interface OpenseaOrder extends Opensea {
-  marketplaceOrder: _OpenseaOrder;
+  marketplaceOrder: OpenseaOriginalOrder;
+  normalizedOrder: NormalizedOrder;
 }
 
 export interface TraderOrder extends Trader {
-  marketplaceOrder: PostOrderResponsePayload;
+  marketplaceOrder: TraderOriginalOrder;
+  normalizedOrder: NormalizedOrder;
 }
 
 export type Order = OpenseaOrder | TraderOrder;


### PR DESCRIPTION
1) Return `normalizedOrder` together with `marketplaceOrder`, that's got same unified structure. Current `normalizedOrder` is based on single-asset order with specific erc20 payment token (which gets address `0x00000...` in case of `ETH`).
2) Refactor type for platform orders. Export `OpenseaOriginalOrder` and `TraderOriginalOrder` from `types` to eliminate confusion within marketplaces implementations (mainly to avoid starting at things like `PostOrderResponsePayload` and `Order`, where it's not always obvious what it means).