### PR TITLE
Improve supported chain ids functionality

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,8 +1,8 @@
 import { Signer } from "@ethersproject/abstract-signer";
 import { Web3Provider } from "@ethersproject/providers";
 
-import { Opensea } from "./marketplaces/Opensea";
-import { Trader } from "./marketplaces/Trader";
+import { Opensea, openseaSupportedChainIds } from "./marketplaces/Opensea";
+import { Trader, traderSupportedChainIds } from "./marketplaces/Trader";
 
 import type { OpenseaConfig } from "./marketplaces/Opensea";
 import type { TraderConfig } from "./marketplaces/Trader";
@@ -41,6 +41,11 @@ interface Marketplaces {
   opensea?: Opensea;
   trader?: Trader;
 }
+
+export const SUPPORTED_CHAIN_IDS_MAPPING: Record<MarketplaceName, number[]> = {
+  opensea: openseaSupportedChainIds,
+  trader: traderSupportedChainIds,
+};
 
 export class Gomu {
   readonly marketplaces: Marketplaces = {};

--- a/packages/sdk/src/marketplaces/Opensea.ts
+++ b/packages/sdk/src/marketplaces/Opensea.ts
@@ -34,6 +34,8 @@ export interface _OpenseaConfig extends OpenseaConfig {
   address: string;
 }
 
+export const openseaSupportedChainIds = [1, 4];
+
 export class Opensea implements Marketplace<Order> {
   private readonly seaport: OpenSeaPort;
   private readonly address: string;
@@ -48,7 +50,7 @@ export class Opensea implements Marketplace<Order> {
   }
 
   static supportsChainId(chainId: number): boolean {
-    return [1, 4].includes(chainId);
+    return openseaSupportedChainIds.includes(chainId);
   }
 
   async makeOrder({

--- a/packages/sdk/src/marketplaces/Trader.ts
+++ b/packages/sdk/src/marketplaces/Trader.ts
@@ -1,6 +1,6 @@
 import { Signer } from "@ethersproject/abstract-signer";
 import { BaseProvider } from "@ethersproject/providers";
-import { NftSwapV4 } from "@traderxyz/nft-swap-sdk";
+import { NftSwapV4, SupportedChainIdsV4 } from "@traderxyz/nft-swap-sdk";
 
 import {
   assertAssetsIsNotBundled,
@@ -32,6 +32,19 @@ export interface _TraderConfig extends TraderConfig {
   signer: Signer;
 }
 
+export const traderSupportedChainIds = Object.keys(SupportedChainIdsV4).reduce(
+  (acc, key) => {
+    const num = Number(key);
+
+    if (Number.isInteger(num)) {
+      acc.push(num);
+    }
+
+    return acc;
+  },
+  [] as number[]
+);
+
 export class Trader implements Marketplace<PostOrderResponsePayload> {
   private readonly nftSwapSdk: NftSwapV4;
   private readonly chainId: number;
@@ -52,7 +65,7 @@ export class Trader implements Marketplace<PostOrderResponsePayload> {
   }
 
   static supportsChainId(chainId: number): boolean {
-    return [1, 3].includes(chainId);
+    return traderSupportedChainIds.includes(chainId);
   }
 
   async makeOrder({


### PR DESCRIPTION
1) Add broader support of chain ids for trader.
2) Export support chain ids mapping, so that it can be used in apps that are integrating this SDK (currently required for widget to properly enable/disables marketplaces in UI for different chains).