### PR TITLE
Trader fees

### DIFF
--- a/packages/sdk/src/marketplaces/Trader.ts
+++ b/packages/sdk/src/marketplaces/Trader.ts
@@ -278,7 +278,7 @@ function calculateFees(
     for (let i = 0; i <= fees.length; i++) {
       const fee = fees[i];
 
-      if (fee.amount > 0) {
+      if ("amount" in fee && fee.amount > 0) {
         if (new BigNumber(String(fee.amount)).gte(new BigNumber(amount))) {
           throw new Error(
             "Fee amount cannot be greater than or equal to amount"
@@ -292,7 +292,7 @@ function calculateFees(
         continue;
       }
 
-      if (fee.basisPoints > 0) {
+      if ("basisPoints" in fee && fee.basisPoints > 0) {
         if (fee.basisPoints >= BASIS_POINTS_100_PERCENT) {
           throw new Error(
             "Fee basis points cannot be greater than or equal to 100% of amount"

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,4 +1,4 @@
-import BigNumber from "bignumber.js";
+import { BigNumberish } from "@ethersproject/bignumber";
 
 import type {
   MakeOrderResult as _LooksRareOrder,
@@ -34,11 +34,11 @@ export type Asset = Erc20Asset | Erc721Asset | Erc1155Asset;
 
 export type FlatAmountFee = { recipient: string; amount: bigint };
 
-export type BigNumberFee = { recipient: string; amount: BigNumber };
-
 export type BasisPointsFee = { recipient: string; basisPoints: number };
 
-export type Fee = FlatAmountFee | BasisPointsFee;
+export type Fee = FlatAmountFee & BasisPointsFee;
+
+export type BigNumberFee = { recipient: string; amount: BigNumberish };
 
 interface MarketplacesConfig {
   trader: {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -46,7 +46,9 @@ export interface BasisPointsFee extends BaseFee {
 
 export type Fee = FlatAmountFee | BasisPointsFee;
 
-export type BigNumberFee = { recipient: string; amount: BigNumberish };
+export interface BigNumberFee extends BaseFee {
+  amount: BigNumberish;
+}
 
 interface MarketplacesConfig {
   trader: {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,9 +1,8 @@
-import { BigNumberish } from "@ethersproject/bignumber";
-
 import type {
   MakeOrderResult as _LooksRareOrder,
   ContractReceipt as _LooksRareContractReceipt,
 } from "./marketplaces/LooksRare";
+import type { BigNumberish } from "@ethersproject/bignumber";
 import type {
   ContractReceipt,
   ContractTransaction,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,3 +1,5 @@
+import BigNumber from "bignumber.js";
+
 import type {
   MakeOrderResult as _LooksRareOrder,
   ContractReceipt as _LooksRareContractReceipt,
@@ -30,6 +32,20 @@ export interface Erc1155Asset {
 
 export type Asset = Erc20Asset | Erc721Asset | Erc1155Asset;
 
+export type FlatAmountFee = { recipient: string; amount: bigint };
+
+export type BigNumberFee = { recipient: string; amount: BigNumber };
+
+export type BasisPointsFee = { recipient: string; basisPoints: number };
+
+export type Fee = FlatAmountFee | BasisPointsFee;
+
+interface MarketplacesConfig {
+  trader: {
+    fees: Fee[];
+  };
+}
+
 export interface MakeOrderParams {
   /** Assets the user has */
   makerAssets: Asset[];
@@ -45,6 +61,9 @@ export interface MakeOrderParams {
 
   /** Selected marketplaces */
   marketplaces?: `${MarketplaceName}`[];
+
+  /** Configs for specific marketplaces */
+  marketplacesConfig?: MarketplacesConfig;
 }
 
 export type MakeSellOrderParams = Omit<

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -32,11 +32,19 @@ export interface Erc1155Asset {
 
 export type Asset = Erc20Asset | Erc721Asset | Erc1155Asset;
 
-export type FlatAmountFee = { recipient: string; amount: bigint };
+interface BaseFee {
+  recipient: string;
+}
 
-export type BasisPointsFee = { recipient: string; basisPoints: number };
+export interface FlatAmountFee extends BaseFee {
+  amount: bigint;
+}
 
-export type Fee = FlatAmountFee & BasisPointsFee;
+export interface BasisPointsFee extends BaseFee {
+  basisPoints: number;
+}
+
+export type Fee = FlatAmountFee | BasisPointsFee;
 
 export type BigNumberFee = { recipient: string; amount: BigNumberish };
 


### PR DESCRIPTION
Adds fees support to `makeOrder` for trader platform via `marketplacesConfig` param.
`Fee` can either be `{ recipient: string; amount: bigint }` or `{recipient: string; basisPoints: number }`.
Method `calculateFees` converts all fees amounts to BigNumber string, and computes BigNumber amount for `basisPoints` (`amount * basisPoints / 10000`). It properly asserts that no specific fee can be greater or equal to ERC20 amount, including the total fee value.
After total fees are computed, they are subtracted from ERC20 amount to give us the final amount, because `nft-swap-sdk` by default adds fees on top of the original amount, while we want fees to be part of the original price.
https://github.com/trader-xyz/nft-swap-sdk/blob/main/src/sdk/v4/NftSwapV4.ts#L1146
