### PR TITLE
feat(sdk): add trader v3 with gomu order book

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,6 +7,11 @@ import {
 } from "./marketplaces/LooksRare";
 import { Opensea, openseaSupportedChainIds } from "./marketplaces/Opensea";
 import { Trader, traderSupportedChainIds } from "./marketplaces/Trader";
+import {
+  TraderV3,
+  TraderV3Config,
+  traderV3SupportedChainIds,
+} from "./marketplaces/TraderV3";
 
 import type { LooksRareConfig } from "./marketplaces/LooksRare";
 import type { OpenseaConfig } from "./marketplaces/Opensea";
@@ -34,6 +39,7 @@ export interface GomuConfig {
   openseaConfig?: OpenseaConfig;
   traderConfig?: TraderConfig;
   looksrareConfig?: LooksRareConfig;
+  traderV3Config?: TraderV3Config;
 }
 
 interface _GomuConfig extends GomuConfig {
@@ -46,6 +52,7 @@ interface Marketplaces {
   opensea?: Opensea;
   trader?: Trader;
   looksrare?: LooksRare;
+  traderV3?: TraderV3;
 }
 
 export const SUPPORTED_CHAIN_IDS_BY_MARKETPLACE: Record<
@@ -55,6 +62,7 @@ export const SUPPORTED_CHAIN_IDS_BY_MARKETPLACE: Record<
   looksrare: looksrareSupportedChainIds,
   opensea: openseaSupportedChainIds,
   trader: traderSupportedChainIds,
+  traderV3: traderV3SupportedChainIds,
 };
 
 export class Gomu {
@@ -65,6 +73,7 @@ export class Gomu {
     openseaConfig = {},
     traderConfig = {},
     looksrareConfig = {},
+    traderV3Config = {},
   }: GomuConfig): Promise<Gomu> {
     const signer = await provider.getSigner();
     const [address, chainId] = await Promise.all([
@@ -79,6 +88,7 @@ export class Gomu {
       openseaConfig,
       traderConfig,
       looksrareConfig,
+      traderV3Config,
     });
   }
 
@@ -90,6 +100,7 @@ export class Gomu {
     openseaConfig,
     traderConfig,
     looksrareConfig,
+    traderV3Config,
   }: _GomuConfig) {
     if (Opensea.supportsChainId(chainId)) {
       this.marketplaces.opensea = new Opensea({
@@ -114,6 +125,16 @@ export class Gomu {
     if (LooksRare.supportsChainId(chainId)) {
       this.marketplaces.looksrare = new LooksRare({
         ...looksrareConfig,
+        chainId,
+        address,
+        signer,
+      });
+    }
+
+    if (TraderV3.supportsChainId(chainId)) {
+      this.marketplaces.traderV3 = new TraderV3({
+        ...traderV3Config,
+        provider,
         chainId,
         address,
         signer,

--- a/packages/sdk/src/marketplaces/TraderV3.ts
+++ b/packages/sdk/src/marketplaces/TraderV3.ts
@@ -1,0 +1,194 @@
+import { Signer } from "@ethersproject/abstract-signer";
+import { ContractReceipt, ContractTransaction } from "@ethersproject/contracts";
+import { BaseProvider } from "@ethersproject/providers";
+import {
+  NftSwapV3,
+  SignedOrder,
+  SupportedChainIdsV3,
+  SwappableAsset,
+} from "@traderxyz/nft-swap-sdk";
+
+import { GomuOrderBook } from "../orderbooks/Gomu";
+import {
+  OrderBook,
+  GetOrdersParams as OrderBookGetOrdersParams,
+} from "../orderbooks/OrderBook";
+import {
+  AnyAsset,
+  Asset,
+  GetOrdersParams,
+  MakeOrderParams,
+  TraderV3Order,
+} from "../types";
+
+import { Marketplace } from "./Marketplace";
+
+export interface TraderV3Config {
+  gasLimit?: number;
+}
+
+export interface _TraderV3Config extends TraderV3Config {
+  provider: BaseProvider;
+  chainId: number;
+  address: string;
+  signer: Signer;
+  orderBook?: OrderBook<SignedOrder>;
+}
+
+export const traderV3SupportedChainIds = Object.keys(SupportedChainIdsV3)
+  .filter((key) => Number.isInteger(Number(key)))
+  .map(Number);
+
+export class TraderV3 implements Marketplace<TraderV3Order> {
+  private readonly nftSwapSdk: NftSwapV3;
+  private readonly chainId: number;
+  private readonly address: string;
+  private readonly gasLimit: number;
+  private orderBook: OrderBook<SignedOrder>;
+
+  constructor({
+    provider,
+    chainId,
+    address,
+    signer,
+    gasLimit = 2000000,
+    orderBook = new GomuOrderBook<SignedOrder>(),
+  }: _TraderV3Config) {
+    this.nftSwapSdk = new NftSwapV3(provider, signer, chainId);
+    this.chainId = chainId;
+    this.address = address;
+    this.gasLimit = gasLimit;
+    this.orderBook = orderBook;
+
+    this.approveAsset = this.approveAsset.bind(this);
+  }
+
+  static supportsChainId(chainId: number): boolean {
+    return traderV3SupportedChainIds.includes(chainId);
+  }
+
+  async makeOrder({
+    makerAssets: _makerAssets,
+    takerAssets: _takerAssets,
+    taker,
+    expirationTime,
+  }: MakeOrderParams): Promise<any> {
+    const makerAssets = _makerAssets.map(getSwappableAssetV3);
+    const takerAssets = _takerAssets.map(getSwappableAssetV3);
+
+    await Promise.all(makerAssets.map(this.approveAsset));
+
+    const order = this.nftSwapSdk.buildOrder(
+      makerAssets,
+      takerAssets,
+      this.address,
+      {
+        takerAddress: taker,
+        expiration: expirationTime,
+      }
+    );
+
+    const signedOrder = await this.nftSwapSdk.signOrder(order, this.address);
+
+    const resp = await this.orderBook.makeOrder({
+      chainId: this.chainId.toString(),
+      maker: this.address,
+      makerAssets: _makerAssets,
+      takerAssets: _takerAssets,
+      taker,
+      originalOrder: signedOrder,
+    });
+
+    return resp.data;
+  }
+
+  async getOrders({
+    makerAsset,
+    maker,
+    takerAsset,
+    taker,
+  }: GetOrdersParams): Promise<any> {
+    const { contractAddress: makerContractAddress, tokenId: makerTokenId } =
+      (makerAsset as AnyAsset) ?? {};
+    const { contractAddress: takerContractAddress, tokenId: takerTokenId } =
+      (takerAsset as AnyAsset) ?? {};
+
+    const params: OrderBookGetOrdersParams = Object.fromEntries(
+      Object.entries({
+        maker,
+        makerContractAddress,
+        makerTokenId,
+        taker,
+        takerContractAddress,
+        takerTokenId,
+      }).filter(([_, v]) => v)
+    );
+
+    const { data } = await this.orderBook.getOrders(params);
+    return data;
+  }
+
+  async takeOrder(order: TraderV3Order): Promise<ContractReceipt> {
+    const { originalOrder: signedOrder } = order;
+
+    const takerAssets: SwappableAsset[] =
+      order.takerAssets.map(getSwappableAssetV3);
+
+    await Promise.all(takerAssets.map(this.approveAsset));
+
+    const fillTx = await this.nftSwapSdk.fillSignedOrder(
+      signedOrder,
+      undefined,
+      {
+        gasLimit: this.gasLimit,
+      }
+    );
+    return fillTx.wait();
+  }
+
+  cancelOrder(order: TraderV3Order): Promise<ContractTransaction> {
+    return this.nftSwapSdk.cancelOrder(order.originalOrder);
+  }
+
+  private async approveAsset(asset: SwappableAsset): Promise<void> {
+    const approvalStatus = await this.nftSwapSdk.loadApprovalStatus(
+      asset,
+      this.address
+    );
+
+    if (!approvalStatus.contractApproved) {
+      const approvalTx = await this.nftSwapSdk.approveTokenOrNftByAsset(
+        asset,
+        this.address
+      );
+      await approvalTx.wait();
+    }
+  }
+}
+
+function getSwappableAssetV3(asset: Asset): SwappableAsset {
+  const { contractAddress, type } = asset;
+  switch (type) {
+    case "ERC20":
+      return {
+        tokenAddress: contractAddress,
+        type,
+        amount: asset.amount.toString(),
+      };
+    case "ERC721":
+      return {
+        tokenAddress: contractAddress,
+        tokenId: asset.tokenId,
+        type,
+      };
+    case "ERC1155":
+      return {
+        tokenAddress: contractAddress,
+        tokenId: asset.tokenId,
+        type,
+        amount: asset.amount.toString(),
+      };
+    default:
+      throw new Error(`unknown asset type: ${type}`);
+  }
+}

--- a/packages/sdk/src/orderbooks/Gomu.ts
+++ b/packages/sdk/src/orderbooks/Gomu.ts
@@ -1,0 +1,68 @@
+import fetch from "isomorphic-unfetch";
+
+import { AnyAsset, Asset } from "../types";
+
+import {
+  GetOrdersParams,
+  GetOrdersResponse,
+  MakeOrderParams,
+  MakeOrderResponse,
+  OrderBook,
+} from "./OrderBook";
+
+export class GomuOrderBook<SignedOrder> implements OrderBook<SignedOrder> {
+  private baseUrl: string = "https://api.gomu.com/commerce";
+
+  async getOrders(
+    getOrdersParams?: GetOrdersParams
+  ): Promise<GetOrdersResponse<SignedOrder>> {
+    let url = `${this.baseUrl}/orders`;
+
+    if (getOrdersParams) {
+      const params = new URLSearchParams(
+        Object.fromEntries(
+          Object.entries(getOrdersParams).filter(([_, v]) => v)
+        )
+      );
+      url += `?${params.toString()}`;
+    }
+
+    const resp = await fetch(url);
+    return resp.json();
+  }
+
+  async makeOrder(
+    makeOrderParams: MakeOrderParams<SignedOrder>
+  ): Promise<MakeOrderResponse<SignedOrder>> {
+    const { makerAssets, takerAssets, ...params } = makeOrderParams;
+
+    const body = JSON.stringify(
+      {
+        ...params,
+        makerAssets: makerAssets.map(makeAnyAsset),
+        takerAssets: takerAssets.map(makeAnyAsset),
+      },
+      (key, value) => (typeof value === "bigint" ? value.toString() : value)
+    );
+
+    const resp = await fetch(`${this.baseUrl}/orders`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    return resp.json();
+  }
+}
+
+function makeAnyAsset(asset: Asset): AnyAsset {
+  if (asset.type === "ERC721") {
+    return {
+      contractAddress: asset.contractAddress,
+      tokenId: asset.tokenId,
+      type: asset.type,
+      amount: BigInt(1),
+    };
+  }
+
+  return asset;
+}

--- a/packages/sdk/src/orderbooks/OrderBook.ts
+++ b/packages/sdk/src/orderbooks/OrderBook.ts
@@ -1,0 +1,40 @@
+import { NormalizedOrder } from "../types";
+
+import { GomuOrderBook } from "./Gomu";
+
+export interface OrderBookOrder<SignedOrder>
+  extends NormalizedOrder<SignedOrder> {
+  chainId: string;
+  taker?: string;
+}
+
+export interface MakeOrderParams<SignedOrder>
+  extends Omit<OrderBookOrder<SignedOrder>, "id"> {}
+
+export interface MakeOrderResponse<SignedOrder> {
+  data: OrderBookOrder<SignedOrder>;
+}
+
+export interface GetOrdersParams {
+  chainId?: string;
+  maker?: string;
+  makerContractAddress?: string;
+  makerTokenId?: string;
+  taker?: string;
+  takerContractAddress?: string;
+  takerTokenId?: string;
+}
+
+export interface GetOrdersResponse<SignedOrder> {
+  data: OrderBookOrder<SignedOrder>[];
+}
+
+export interface OrderBook<SignedOrder> {
+  makeOrder(
+    makeOrderParams: MakeOrderParams<SignedOrder>
+  ): Promise<MakeOrderResponse<SignedOrder>>;
+
+  getOrders(
+    getOrdersParams: GetOrdersParams
+  ): Promise<GetOrdersResponse<SignedOrder>>;
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,10 +1,14 @@
+import { SignedOrder } from "@traderxyz/nft-swap-sdk";
+
+import { OrderBookOrder } from "./orderbooks/OrderBook";
+
 import type {
   LooksRareOriginalOrder,
   ContractReceipt as _LooksRareContractReceipt,
 } from "./marketplaces/LooksRare";
 import type {
-  ContractReceipt as TraderContractReceipt,
-  ContractTransaction as TraderContractTransaction,
+  ContractReceipt,
+  ContractTransaction,
 } from "@ethersproject/contracts";
 import type { PostOrderResponsePayload as TraderOriginalOrder } from "@traderxyz/nft-swap-sdk/dist/sdk/v4/orderbook";
 import type { OrderV2 as OpenseaOriginalOrder } from "opensea-js/lib/orders/types";
@@ -92,6 +96,7 @@ export enum MarketplaceName {
   Opensea = "opensea",
   Trader = "trader",
   LooksRare = "looksrare",
+  TraderV3 = "traderV3",
 }
 
 export interface NormalizedOrder<OriginalOrder> {
@@ -107,6 +112,8 @@ export type OpenseaOrder = NormalizedOrder<OpenseaOriginalOrder>;
 export type TraderOrder = NormalizedOrder<TraderOriginalOrder>;
 
 export type LooksRareOrder = NormalizedOrder<LooksRareOriginalOrder>;
+
+export type TraderV3Order = OrderBookOrder<SignedOrder>;
 
 interface ResponseBase<N extends MarketplaceName> {
   marketplaceName: N;
@@ -140,10 +147,16 @@ export type LooksRareOrderResponse = Response<
   LooksRareOrder
 >;
 
+export type TraderV3OrderResponse = Response<
+  MarketplaceName.TraderV3,
+  TraderV3Order
+>;
+
 export type OrderResponse =
   | OpenseaOrderResponse
   | TraderOrderResponse
-  | LooksRareOrderResponse;
+  | LooksRareOrderResponse
+  | TraderV3OrderResponse;
 
 export interface GetOrdersParams {
   maker?: string;
@@ -155,28 +168,35 @@ export interface GetOrdersParams {
 type OpenseaResponseData<D> = ResponseData<MarketplaceName.Opensea, D>;
 type TraderResponseData<D> = ResponseData<MarketplaceName.Trader, D>;
 type LooksRareResponseData<D> = ResponseData<MarketplaceName.LooksRare, D>;
+type TraderV3ResponseData<D> = ResponseData<MarketplaceName.TraderV3, D>;
 
 export type OpenseaTakeOrderResponse = OpenseaResponseData<string>;
 
-export type TraderTakeOrderResponse = TraderResponseData<TraderContractReceipt>;
+export type TraderTakeOrderResponse = TraderResponseData<ContractReceipt>;
 
 export type LooksRareTakeOrderResponse =
   LooksRareResponseData<_LooksRareContractReceipt>;
 
+export type TraderV3TakeOrderResponse = TraderV3ResponseData<ContractReceipt>;
+
 export type TakeOrderResponse =
   | OpenseaTakeOrderResponse
   | TraderTakeOrderResponse
-  | LooksRareTakeOrderResponse;
+  | LooksRareTakeOrderResponse
+  | TraderV3TakeOrderResponse;
 
 export type OpenseaCancelOrderResponse = OpenseaResponseData<void>;
 
-export type TraderCancelOrderResponse =
-  TraderResponseData<TraderContractTransaction>;
+export type TraderCancelOrderResponse = TraderResponseData<ContractTransaction>;
 
 export type LooksRareCancelOrderResponse =
   LooksRareResponseData<_LooksRareContractReceipt>;
 
+export type TraderV3CancelOrderResponse =
+  TraderV3ResponseData<ContractTransaction>;
+
 export type CancelOrderResponse =
   | OpenseaCancelOrderResponse
   | TraderCancelOrderResponse
-  | LooksRareCancelOrderResponse;
+  | LooksRareCancelOrderResponse
+  | TraderV3CancelOrderResponse;


### PR DESCRIPTION
Add a trader v3 marketplace (mostly copied from trader v4) that uses the gomu order book.

Right now, the order book is a simple CRUD backend that is not monitoring events from the chain. For simplicity, we could post status updates to the order book after confirmation from ethers after cancelling and taking (but isn't done so in this PR).

What is more important is the query pattern required to fetch orders. Right now I only have a very simple query params of maker address, maker asset, taker address, taker asset. We'll probably need an active, cancelled, expired status, which I can add next. Let me know what else is required.