### PR TITLE
feat: add trader v3 maker and taker fees

### DIFF
--- a/packages/sdk/src/marketplaces/TraderV3.ts
+++ b/packages/sdk/src/marketplaces/TraderV3.ts
@@ -2,6 +2,10 @@ import { Signer } from "@ethersproject/abstract-signer";
 import { ContractReceipt, ContractTransaction } from "@ethersproject/contracts";
 import { BaseProvider } from "@ethersproject/providers";
 import {
+  convertAssetsToInternalFormat,
+  encodeAssetData,
+  encodeMultiAssetAssetData,
+  getAmountFromAsset,
   NftSwapV3,
   SignedOrder,
   SupportedChainIdsV3,
@@ -16,6 +20,7 @@ import {
 import {
   AnyAsset,
   Asset,
+  FeeAsset,
   GetOrdersParams,
   MakeOrderParams,
   TraderV3Order,
@@ -72,11 +77,15 @@ export class TraderV3 implements Marketplace<TraderV3Order> {
     takerAssets: _takerAssets,
     taker,
     expirationTime,
+    makerFees,
+    takerFees,
   }: MakeOrderParams): Promise<any> {
     const makerAssets = _makerAssets.map(getSwappableAssetV3);
     const takerAssets = _takerAssets.map(getSwappableAssetV3);
 
     await Promise.all(makerAssets.map(this.approveAsset));
+
+    const feeConfig = getFeeConfig({ makerFees, takerFees });
 
     const order = this.nftSwapSdk.buildOrder(
       makerAssets,
@@ -85,6 +94,7 @@ export class TraderV3 implements Marketplace<TraderV3Order> {
       {
         takerAddress: taker,
         expiration: expirationTime,
+        ...feeConfig,
       }
     );
 
@@ -189,4 +199,76 @@ function getSwappableAssetV3(asset: Asset): SwappableAsset {
     default:
       throw new Error(`unknown asset type: ${type}`);
   }
+}
+
+function getFeeConfig({
+  makerFees = [],
+  takerFees = [],
+}: {
+  makerFees?: FeeAsset[];
+  takerFees?: FeeAsset[];
+}): {
+  feeRecipientAddress?: string;
+  makerFeeAssetData?: string;
+  takerFeeAssetData?: string;
+  makerFee?: string;
+  takerFee?: string;
+} {
+  const recipientAddresses = [
+    ...new Set(
+      makerFees
+        .map(byRecipientAddress)
+        .concat(takerFees.map(byRecipientAddress))
+    ),
+  ];
+  if (recipientAddresses.length > 1) {
+    throw new Error("cannot have more than 1 recipient address");
+  }
+
+  let feeRecipientAddress: string | undefined;
+  if (recipientAddresses.length === 1) {
+    feeRecipientAddress = recipientAddresses[0];
+  }
+
+  const { amount: makerFee, data: makerFeeAssetData } =
+    getFeeData(makerFees.map(getSwappableAssetV3)) || {};
+  const { amount: takerFee, data: takerFeeAssetData } =
+    getFeeData(takerFees.map(getSwappableAssetV3)) || {};
+
+  return {
+    feeRecipientAddress,
+    makerFeeAssetData,
+    takerFeeAssetData,
+    makerFee,
+    takerFee,
+  };
+}
+
+function byRecipientAddress(asset: FeeAsset): string {
+  return asset.recipientAddress;
+}
+
+function getFeeData(_assets: SwappableAsset[]): {
+  amount: string;
+  data: string;
+} | null {
+  if (!_assets.length) {
+    return null;
+  }
+
+  const assets = convertAssetsToInternalFormat(_assets);
+  if (assets.length === 1) {
+    const asset = assets[0];
+    return {
+      amount: getAmountFromAsset(asset),
+      data: encodeAssetData(asset, false),
+    };
+  }
+
+  const amounts = assets.map((asset) => getAmountFromAsset(asset));
+  const datas = assets.map((asset) => encodeAssetData(asset, true));
+  return {
+    amount: "1", // Needs to be 1 for multiasset wrapper amount (actual amounts are nested)
+    data: encodeMultiAssetAssetData(amounts, datas),
+  };
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -65,6 +65,20 @@ export type AnyAsset = Merge<
 > &
   Asset;
 
+interface Erc20FeeAsset extends Erc20Asset {
+  recipientAddress: string;
+}
+
+interface Erc721FeeAsset extends Erc721Asset {
+  recipientAddress: string;
+}
+
+interface Erc1155FeeAsset extends Erc1155Asset {
+  recipientAddress: string;
+}
+
+export type FeeAsset = Erc20FeeAsset | Erc721FeeAsset | Erc1155FeeAsset;
+
 export interface MakeOrderParams {
   /** Assets the user has */
   makerAssets: Asset[];
@@ -80,6 +94,12 @@ export interface MakeOrderParams {
 
   /** Selected marketplaces */
   marketplaces?: `${MarketplaceName}`[];
+
+  /** Fees payable by the maker */
+  makerFees?: FeeAsset[];
+
+  /** Fees payable by the taker */
+  takerFees?: FeeAsset[];
 }
 
 export type MakeSellOrderParams = Omit<


### PR DESCRIPTION
This allows users to input maker fees which will be paid by the maker, and taker fees are paid by the taker. The fees do not have to be part of the maker / taker assets. Therefore, basis point and flat fees cannot be supported.