### PR TITLE
feat: improve error formatting

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -169,6 +169,7 @@ export class Gomu {
               marketplaceName: marketplaceName as MarketplaceName,
               error: {
                 message: formatError(err),
+                cause: err,
               },
             };
           }
@@ -221,6 +222,7 @@ export class Gomu {
                     marketplaceName: marketplaceName as MarketplaceName,
                     error: {
                       message: formatError(err),
+                      cause: err,
                     },
                   },
                 ];
@@ -279,5 +281,13 @@ export class Gomu {
 }
 
 function formatError(err: unknown): string {
-  return err instanceof Error ? err.message : `${err}`;
+  if (Object.hasOwnProperty.call(err, "message")) {
+    return (err as { message: string }).message;
+  }
+
+  try {
+    return JSON.stringify(err);
+  } catch (_) {
+    return `${err}`;
+  }
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -126,6 +126,7 @@ interface ResponseData<N extends MarketplaceName, D> extends ResponseBase<N> {
 interface ResponseError<N extends MarketplaceName> extends ResponseBase<N> {
   error: {
     message: string;
+    cause: any;
   };
 }
 


### PR DESCRIPTION
- Handle errors objects that are not instances of `Error` + try to serialize errors otherwise before trying to cast into string (otherwise we may end up with `[object Object]` as error message)
- Include original error object within payload